### PR TITLE
Add debug-statements and preserve unicode in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: name-tests-test
+      - id: debug-statements
 
   - repo: https://github.com/d-ryzhykau/pipenv-lock-pre-commit
     rev: 0.5.0
@@ -126,6 +127,7 @@ repos:
       - id: pretty-format-json
         args:
           - "--autofix"
+          - "--no-ensure-ascii"
 
 # ----- Project structure
 


### PR DESCRIPTION
- debug-statements - to avoid committing forgotten breakpoints
- --no-ensure-ascii - to avoid unintended changes to unicode strings when formatting JSON files.